### PR TITLE
Address MDL-83705 by fixing subplugins.json

### DIFF
--- a/db/subplugins.json
+++ b/db/subplugins.json
@@ -1,5 +1,5 @@
 {
-    "subplugintypes" {
+    "subplugintypes": {
         "ivplugin":"plugins"
     },
     "plugintypes": {

--- a/db/subplugins.json
+++ b/db/subplugins.json
@@ -1,4 +1,7 @@
 {
+    "subplugintypes" {
+        "ivplugin":"plugins"
+    },
     "plugintypes": {
       "ivplugin": "mod\/interactivevideo\/plugins"
     }


### PR DESCRIPTION
## Summary

Fixes the recurring PHP deprecation notice on Moodle 5.1+ by adding the missing `subplugintypes` key to `subplugins.json`, as required by MDL-83705.

## Background / Problem

On Moodle 5.1 (and potentially other versions), PHP emits a deprecation warning on every execution when `subplugins.json` does not include a `subplugintypes` definition. This results in noisy logs and obscures actionable warnings.

Reference: MDL-83705 (https://moodle.atlassian.net/browse/MDL-83705)

## Change

Adds the required `subplugintypes` section to `subplugins.json` while preserving the existing `plugintypes` mapping.

### Before

```json
{
  "plugintypes": {
    "ivplugin": "mod/interactivevideo/plugins"
  }
}
```
### After
```json
{
  "subplugintypes": {
    "ivplugin": "plugins"
  },
  "plugintypes": {
    "ivplugin": "mod/interactivevideo/plugins"
  }
}
```
### Impact

- Eliminates repeated deprecation notices related to missing `subplugintypes`
- No functional behaviour change expected (configuration metadata update only)

### Testing

- Verified that Moodle 5.1 no longer logs the deprecation warning related to `subplugins.json` on plugin discovery/load.

> Pull request description enhanced by AI
